### PR TITLE
Add publishing environment variables

### DIFF
--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -31,3 +31,6 @@ jobs:
         uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
         with:
           arguments: publish
+          env:
+            USERNAME: ${{ github.actor }}
+            TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The missing `USERNAME` and `TOKEN` environment variables (erroneously removed in #5) are necessary for publishing the library with GitHub Packages.