### PR TITLE
Remove GitHub username and token retrieval from `local.properties`

### DIFF
--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -21,8 +21,8 @@ object Versions {
     val java = JavaVersion.VERSION_11
 
     object Aurelius {
-        const val CODE = 2
-        const val NAME = "1.1.0"
+        const val CODE = 4
+        const val NAME = "1.1.1"
         const val SDK_COMPILE = 33
         const val SDK_MIN = 21
         const val SDK_TARGET = SDK_COMPILE

--- a/buildSrc/src/main/java/utils/RepositoryHandler.extensions.kt
+++ b/buildSrc/src/main/java/utils/RepositoryHandler.extensions.kt
@@ -15,8 +15,8 @@ fun RepositoryHandler.aurelius(project: Project): MavenArtifactRepository {
 
         credentials {
             with(localProperties(project.rootDir)) {
-                username = getProperty("github.username") ?: System.getenv("GITHUB_USERNAME")
-                password = getProperty("github.token") ?: System.getenv("GITHUB_TOKEN")
+                username = System.getenv("GITHUB_USERNAME")
+                password = System.getenv("GITHUB_TOKEN")
             }
         }
     }


### PR DESCRIPTION
This would be useful if `RepositoryHandler.aurelius` was available for every project that imported Aurelius, because the project that wants to use the library would have the credentials in `local.properties` and would be able to be run locally without any errors; but, unfortunately, that makes no sense: in order to use the library, you have to provide the URL and the credentials **at the project that will use it**, which is exactly what that extension does.

To clarify: the idea was for the extension to be used by outside projects for them to import Aurelius, but for them to do so they have to do exactly what the extension does. Meaning that it's only useful right here, since the outer project won't have access to it because it won't yet have Aurelius' sources.

https://github.com/jeanbarrossilva/Aurelius/blob/b4fbbab0574068db5babf61c3f73cec2907d331d/buildSrc/src/main/java/utils/RepositoryHandler.extensions.kt#L6-L23

That's not confusing at all. 🙂👍🏽