### PR TITLE
Fix crash due to `TopAppBar`'s height animating from `Dp.Unspecified`

### DIFF
--- a/aurelius/src/androidTest/java/com/jeanbarrossilva/aurelius/ui/layout/scaffold/topappbar/TopAppBarTests.kt
+++ b/aurelius/src/androidTest/java/com/jeanbarrossilva/aurelius/ui/layout/scaffold/topappbar/TopAppBarTests.kt
@@ -1,0 +1,24 @@
+package com.jeanbarrossilva.aurelius.ui.layout.scaffold.topappbar
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import com.jeanbarrossilva.aurelius.ui.theme.AureliusTheme
+import org.junit.Rule
+import org.junit.Test
+
+internal class TopAppBarTests {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun doesNotThrowWhenPlacedWhileExpanded() {
+        composeRule.setContent {
+            AureliusTheme {
+                TopAppBar(isCompact = false)
+            }
+        }
+    }
+
+    companion object {
+        private const val COMPACT_TAG = "compact"
+    }
+}

--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/layout/scaffold/topappbar/TopAppBar.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/layout/scaffold/topappbar/TopAppBar.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.layout.onPlaced
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -34,6 +35,9 @@ import androidx.constraintlayout.compose.Dimension
 import com.jeanbarrossilva.aurelius.ui.theme.AureliusTheme
 import com.jeanbarrossilva.aurelius.utils.`if`
 import com.jeanbarrossilva.aurelius.utils.toDpSize
+
+/** Tag that identifies the [TopAppBar] for testing purposes. **/
+internal const val TOP_APP_BAR_TAG = "top_app_bar"
 
 internal val topAppBarBackgroundColor
     @Composable get() = AureliusTheme.colors.container.secondary
@@ -120,12 +124,12 @@ fun TopAppBar(
         if (isCompact) AureliusTheme.sizes.spacing.medium else AureliusTheme.sizes.spacing.large,
         AureliusTheme.animation.spec()
     )
-    var fullHeight by remember { mutableStateOf(Dp.Unspecified) }
+    var expandedHeight by remember { mutableStateOf(Dp.Unspecified) }
     val currentHeight by animateDpAsState(
         if (isCompact) {
             64.dp + AureliusTheme.sizes.margin.statusBar.calculateTopPadding()
         } else {
-            fullHeight.takeOrElse {
+            expandedHeight.takeOrElse {
                 Dp.Infinity
             }
         },
@@ -137,8 +141,8 @@ fun TopAppBar(
             .fillMaxWidth()
             .`if`(currentHeight.isSpecified) { height(currentHeight) }
             .onPlaced {
-                if (fullHeight.isUnspecified) {
-                    fullHeight = it.size.toDpSize(density).height
+                if (expandedHeight.isUnspecified) {
+                    expandedHeight = it.size.toDpSize(density).height
                 }
             }
             .background(containerBrush)
@@ -179,7 +183,7 @@ internal fun TopAppBar(isCompact: Boolean, modifier: Modifier = Modifier) {
         isCompact,
         navigationButton = { MenuButton(onClick = { }) },
         title = { Text("Title") },
-        modifier,
+        modifier.testTag(TOP_APP_BAR_TAG),
         subtitle = { Text("Subtitle") }
     )
 }

--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/layout/scaffold/topappbar/TopAppBar.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/layout/scaffold/topappbar/TopAppBar.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.unit.isUnspecified
+import androidx.compose.ui.unit.takeOrElse
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.constraintlayout.compose.Dimension
 import com.jeanbarrossilva.aurelius.ui.theme.AureliusTheme
@@ -124,7 +125,9 @@ fun TopAppBar(
         if (isCompact) {
             64.dp + AureliusTheme.sizes.margin.statusBar.calculateTopPadding()
         } else {
-            fullHeight
+            fullHeight.takeOrElse {
+                Dp.Infinity
+            }
         },
         AureliusTheme.animation.spec()
     )
@@ -134,7 +137,7 @@ fun TopAppBar(
             .fillMaxWidth()
             .`if`(currentHeight.isSpecified) { height(currentHeight) }
             .onPlaced {
-                if (currentHeight.isUnspecified) {
+                if (fullHeight.isUnspecified) {
                     fullHeight = it.size.toDpSize(density).height
                 }
             }

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -21,8 +21,8 @@ object Versions {
     val java = JavaVersion.VERSION_11
 
     object Aurelius {
-        const val CODE = 4
-        const val NAME = "1.2.0"
+        const val CODE = 6
+        const val NAME = "1.2.1"
         const val SDK_COMPILE = 33
         const val SDK_MIN = 21
         const val SDK_TARGET = SDK_COMPILE


### PR DESCRIPTION
Placing a [`TopAppBar`](https://github.com/jeanbarrossilva/aurelius-android/blob/32ee5787e0dac8591b14232ff5100bed3a4be215/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/layout/scaffold/topappbar/TopAppBar.kt) would cause the app to crash because its initial known height is [`Dp.Unspecified`](https://developer.android.com/reference/kotlin/androidx/compose/ui/unit/Dp), that holds a [`Float.NaN`](https://en.wikipedia.org/wiki/NaN) which, in turn, cannot be animated from or to by Compose.