### PR TITLE
Add `AureliusTheme.requireFor`

### DIFF
--- a/aurelius/src/androidTest/java/com/jeanbarrossilva/aurelius/fixtures/Instrumentation.extensions.kt
+++ b/aurelius/src/androidTest/java/com/jeanbarrossilva/aurelius/fixtures/Instrumentation.extensions.kt
@@ -1,4 +1,4 @@
-package com.jeanbarrossilva.aurelius.utils // ktlint-disable filename
+package com.jeanbarrossilva.aurelius.fixtures // ktlint-disable filename
 
 import android.app.Activity
 import android.app.Instrumentation

--- a/aurelius/src/androidTest/java/com/jeanbarrossilva/aurelius/fixtures/Window.extensions.kt
+++ b/aurelius/src/androidTest/java/com/jeanbarrossilva/aurelius/fixtures/Window.extensions.kt
@@ -1,4 +1,4 @@
-package com.jeanbarrossilva.aurelius.utils
+package com.jeanbarrossilva.aurelius.fixtures // ktlint-disable filename
 
 import android.view.Window
 import androidx.core.view.WindowInsetsControllerCompat

--- a/aurelius/src/androidTest/java/com/jeanbarrossilva/aurelius/ui/input/EditableTextTests.kt
+++ b/aurelius/src/androidTest/java/com/jeanbarrossilva/aurelius/ui/input/EditableTextTests.kt
@@ -35,7 +35,7 @@ internal class EditableTextTests {
             EditableText(isActive = true)
         }
         composeRule.onNodeWithTag(EDITABLE_TEXT_TAG).performClick()
-        composeRule.waitUntil(timeoutMillis = 4_000) { keyboard is Keyboard.Open }
+        composeRule.waitUntil(timeoutMillis = 16_000) { keyboard is Keyboard.Open }
         assertEquals(Keyboard.Open::class, keyboard::class)
     }
 

--- a/aurelius/src/androidTest/java/com/jeanbarrossilva/aurelius/ui/layout/scaffold/topappbar/TopAppBarTests.kt
+++ b/aurelius/src/androidTest/java/com/jeanbarrossilva/aurelius/ui/layout/scaffold/topappbar/TopAppBarTests.kt
@@ -9,6 +9,13 @@ internal class TopAppBarTests {
     @get:Rule
     val composeRule = createComposeRule()
 
+    @Test(expected = IllegalStateException::class)
+    fun throwsOnUnprovidedTheme() {
+        composeRule.setContent {
+            TopAppBar(isCompact = false)
+        }
+    }
+
     @Test
     fun doesNotThrowWhenPlacedWhileExpanded() {
         composeRule.setContent {
@@ -16,9 +23,5 @@ internal class TopAppBarTests {
                 TopAppBar(isCompact = false)
             }
         }
-    }
-
-    companion object {
-        private const val COMPACT_TAG = "compact"
     }
 }

--- a/aurelius/src/androidTest/java/com/jeanbarrossilva/aurelius/ui/system/keyboard/KeyboardEffectTests.kt
+++ b/aurelius/src/androidTest/java/com/jeanbarrossilva/aurelius/ui/system/keyboard/KeyboardEffectTests.kt
@@ -3,8 +3,8 @@ package com.jeanbarrossilva.aurelius.ui.system.keyboard
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.core.view.WindowInsetsCompat
 import androidx.test.platform.app.InstrumentationRegistry
-import com.jeanbarrossilva.aurelius.utils.activity
-import com.jeanbarrossilva.aurelius.utils.insetsControllerCompat
+import com.jeanbarrossilva.aurelius.fixtures.activity
+import com.jeanbarrossilva.aurelius.fixtures.insetsControllerCompat
 import org.junit.Assert.assertEquals
 import org.junit.Rule
 import org.junit.Test

--- a/aurelius/src/androidTest/java/com/jeanbarrossilva/aurelius/ui/theme/AureliusTheme.extensions.kt
+++ b/aurelius/src/androidTest/java/com/jeanbarrossilva/aurelius/ui/theme/AureliusTheme.extensions.kt
@@ -1,0 +1,10 @@
+package com.jeanbarrossilva.aurelius.ui.theme
+
+import androidx.compose.runtime.Composable
+
+/** Calls [AureliusTheme.requireFor] with a `"Test"` [String]. **/
+@Composable
+@Suppress("ComposableNaming")
+internal fun AureliusTheme.require() {
+    requireFor("Test")
+}

--- a/aurelius/src/androidTest/java/com/jeanbarrossilva/aurelius/ui/theme/AureliusThemeTests.kt
+++ b/aurelius/src/androidTest/java/com/jeanbarrossilva/aurelius/ui/theme/AureliusThemeTests.kt
@@ -37,7 +37,7 @@ internal class AureliusThemeTests {
     @Test(expected = IllegalStateException::class)
     fun throwsWhenRequiredWhileNotProvided() {
         composeRule.setContent {
-            AureliusTheme.requireFor("Test")
+            AureliusTheme.require()
         }
     }
 
@@ -49,7 +49,7 @@ internal class AureliusThemeTests {
             }
 
             Text("This one isn't, though.")
-            AureliusTheme.requireFor("Test")
+            AureliusTheme.require()
         }
     }
 
@@ -57,7 +57,7 @@ internal class AureliusThemeTests {
     fun doesNotThrowWhenRequiredWhileProvided() {
         composeRule.setContent {
             AureliusTheme {
-                AureliusTheme.requireFor("Test")
+                AureliusTheme.require()
             }
         }
     }

--- a/aurelius/src/androidTest/java/com/jeanbarrossilva/aurelius/ui/theme/AureliusThemeTests.kt
+++ b/aurelius/src/androidTest/java/com/jeanbarrossilva/aurelius/ui/theme/AureliusThemeTests.kt
@@ -1,0 +1,64 @@
+package com.jeanbarrossilva.aurelius.ui.theme
+
+import androidx.compose.material.Text
+import androidx.compose.ui.test.junit4.createComposeRule
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+
+internal class AureliusThemeTests {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun isProvided() {
+        composeRule.setContent {
+            AureliusTheme {
+                assertTrue(AureliusTheme.isProvided)
+            }
+        }
+    }
+
+    @Test
+    fun isNotProvided() {
+        composeRule.setContent {
+            assertFalse(AureliusTheme.isProvided)
+        }
+    }
+
+    @Test(expected = AssertionError::class)
+    fun throwsWhenRequiringWithABlankContext() {
+        composeRule.setContent {
+            AureliusTheme.requireFor(" ")
+        }
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun throwsWhenRequiredWhileNotProvided() {
+        composeRule.setContent {
+            AureliusTheme.requireFor("Test")
+        }
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun throwsWhenRequiredWhileOnlyProvidedToAnotherContext() {
+        composeRule.setContent {
+            AureliusTheme {
+                Text("This text is themed!")
+            }
+
+            Text("This one isn't, though.")
+            AureliusTheme.requireFor("Test")
+        }
+    }
+
+    @Test
+    fun doesNotThrowWhenRequiredWhileProvided() {
+        composeRule.setContent {
+            AureliusTheme {
+                AureliusTheme.requireFor("Test")
+            }
+        }
+    }
+}

--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/layout/scaffold/topappbar/TopAppBar.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/layout/scaffold/topappbar/TopAppBar.kt
@@ -119,6 +119,8 @@ fun TopAppBar(
     subtitle: @Composable () -> Unit = { },
     actions: @Composable RowScope.() -> Unit = { }
 ) {
+    AureliusTheme.requireFor("TopAppBar")
+
     val density = LocalDensity.current
     val spacing by animateDpAsState(
         if (isCompact) AureliusTheme.sizes.spacing.medium else AureliusTheme.sizes.spacing.large,

--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/AureliusTheme.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/AureliusTheme.kt
@@ -33,6 +33,11 @@ import com.jeanbarrossilva.aurelius.ui.theme.visibility.VisibilityProvider
  * [visibility].
  **/
 object AureliusTheme {
+    /** Whether or not an [AureliusTheme] has been provided. **/
+    internal val isProvided
+        @Composable get() = animation != Animation.Default && colors != Colors.Unspecified &&
+            sizes != Sizes.Unspecified && text != Text.Default && visibility != Visibility.Zero
+
     /** Current [Animation] from [LocalAnimation]. **/
     val animation
         @Composable get() = LocalAnimation.current
@@ -52,6 +57,23 @@ object AureliusTheme {
     /** Current [Visibility] from [LocalVisibility]. **/
     val visibility
         @Composable get() = LocalVisibility.current
+
+    /**
+     * Throws an [IllegalStateException] if an [AureliusTheme] hasn't been provided.
+     *
+     * @param context Context in which the theme is required.
+     **/
+    @Composable
+    @Suppress("ComposableNaming")
+    internal fun requireFor(context: String) {
+        assert(context.isNotBlank()) {
+            "Context should be provided for a more descriptive error message."
+        }
+
+        if (!isProvided) {
+            error("$context requires an AureliusTheme.")
+        }
+    }
 }
 
 /**
@@ -77,9 +99,10 @@ fun AureliusTheme(content: @Composable () -> Unit) {
                                     small = RoundedCornerShape(14.dp),
                                     large = RoundedCornerShape(24.dp)
                                 ),
-                                text.material,
-                                content
-                            )
+                                text.material
+                            ) {
+                                content()
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Makes the provision of an `AureliusTheme` mandatory for certain layouts or UI components.