### PR TITLE
Rename all default theme configs to "unspecified"

### DIFF
--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/AureliusTheme.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/AureliusTheme.kt
@@ -35,8 +35,9 @@ import com.jeanbarrossilva.aurelius.ui.theme.visibility.VisibilityProvider
 object AureliusTheme {
     /** Whether or not an [AureliusTheme] has been provided. **/
     internal val isProvided
-        @Composable get() = animation != Animation.Default && colors != Colors.Unspecified &&
-            sizes != Sizes.Unspecified && text != Text.Default && visibility != Visibility.Zero
+        @Composable get() = animation != Animation.Unspecified && colors != Colors.Unspecified &&
+            sizes != Sizes.Unspecified && text != Text.Unspecified &&
+            visibility != Visibility.Unspecified
 
     /** Current [Animation] from [LocalAnimation]. **/
     val animation

--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/animation/Animation.extensions.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/animation/Animation.extensions.kt
@@ -5,5 +5,5 @@ import androidx.compose.runtime.compositionLocalOf
 
 /** [CompositionLocal] that provides an [Animation]. **/
 internal val LocalAnimation = compositionLocalOf {
-    Animation.Default
+    Animation.Unspecified
 }

--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/animation/Animation.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/animation/Animation.kt
@@ -18,9 +18,9 @@ abstract class Animation internal constructor() {
         FiniteAnimationSpec<T>
 
     companion object {
-        /** [Animation] with an [AnimationDurations.Zero] and a [spring][spring] [spec]. **/
-        internal val Default = object : Animation() {
-            override val durations = AnimationDurations.Zero
+        /** [Animation] with an [AnimationDurations.Unspecified] and a [spring][spring] [spec]. **/
+        internal val Unspecified = object : Animation() {
+            override val durations = AnimationDurations.Unspecified
 
             override fun <T> spec(duration: AnimationDurations.() -> Duration):
                 FiniteAnimationSpec<T> {

--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/animation/AnimationDurations.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/animation/AnimationDurations.kt
@@ -16,7 +16,7 @@ data class AnimationDurations internal constructor(
 ) {
     companion object {
         /** [AnimationDurations] with [Duration.ZERO] values. **/
-        internal val Zero =
+        internal val Unspecified =
             AnimationDurations(fast = Duration.ZERO, medium = Duration.ZERO, slow = Duration.ZERO)
     }
 }

--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/text/Text.extensions.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/text/Text.extensions.kt
@@ -5,5 +5,5 @@ import androidx.compose.runtime.compositionLocalOf
 
 /** [CompositionLocal] that provides [Text]. **/
 internal val LocalText = compositionLocalOf {
-    Text.Default
+    Text.Unspecified
 }

--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/text/Text.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/text/Text.kt
@@ -39,9 +39,9 @@ data class Text internal constructor(
 
     companion object {
         /** [Text] with default values. **/
-        internal val Default = Text(
+        internal val Unspecified = Text(
             headline = TextStyle.Default,
-            title = Title.Default,
+            title = Title.Unspecified,
             body = TextStyle.Default,
             label = TextStyle.Default
         )

--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/text/Title.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/text/Title.kt
@@ -11,6 +11,6 @@ import androidx.compose.ui.text.TextStyle
 data class Title internal constructor(val large: TextStyle, val small: TextStyle) {
     companion object {
         /** [Title] with [TextStyle.Default] values. **/
-        internal val Default = Title(large = TextStyle.Default, small = TextStyle.Default)
+        internal val Unspecified = Title(large = TextStyle.Default, small = TextStyle.Default)
     }
 }

--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/visibility/Visibility.extensions.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/visibility/Visibility.extensions.kt
@@ -5,5 +5,5 @@ import androidx.compose.runtime.compositionLocalOf
 
 /** [CompositionLocal] that provides a [Visibility]. **/
 internal val LocalVisibility = compositionLocalOf {
-    Visibility.Zero
+    Visibility.Unspecified
 }

--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/visibility/Visibility.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/visibility/Visibility.kt
@@ -14,6 +14,6 @@ data class Visibility internal constructor(
 ) {
     companion object {
         /** [Visibility] with zeroed values. **/
-        internal val Zero = Visibility(medium = 0f, low = 0f)
+        internal val Unspecified = Visibility(medium = 0f, low = 0f)
     }
 }


### PR DESCRIPTION
Padronizes the naming of theme configurations, whereas before it'd just follow whatever the underlying data structure's was.