### PR TITLE
Make colors customizable

### DIFF
--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/AureliusTheme.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/AureliusTheme.kt
@@ -81,11 +81,12 @@ object AureliusTheme {
  * Themes the given [content] by providing [colors], [text], [sizes] and [visibility][visibility]
  * values to their respective [CompositionLocal]s and sets up the system bars.
  *
+ * @param colors [Colors] for coloring the [content].
  * @param content Content to be themed.
  **/
 @Composable
-fun AureliusTheme(content: @Composable () -> Unit) {
-    ColorsProvider {
+fun AureliusTheme(colors: Colors = Colors.default, content: @Composable () -> Unit) {
+    ColorsProvider(colors) {
         SystemBarsConfigurationEffect()
 
         AnimationProvider {

--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/colors/Colors.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/colors/Colors.kt
@@ -5,6 +5,9 @@ import androidx.compose.material3.ColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
+import com.jeanbarrossilva.aurelius.R
+import com.jeanbarrossilva.aurelius.ui.theme.colors.layered.LayeredColors
+import com.jeanbarrossilva.aurelius.ui.theme.colors.layered.LayeredColorsDefaults
 
 /**
  * Palette for various contexts.
@@ -64,6 +67,16 @@ data class Colors internal constructor(
             content = LayeredColors.Unspecified,
             TextColors.Unspecified
         )
+
+        /** [Colors] that are provided by default. **/
+        val default
+            @Composable get() = of(
+                R.color.aurelius_background,
+                R.color.aurelius_scrim,
+                LayeredColorsDefaults.container,
+                LayeredColorsDefaults.content,
+                TextColors.default
+            )
 
         /**
          * Creates [Colors] by getting the corresponding [Color] for the given [background] resource

--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/colors/ColorsProvider.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/colors/ColorsProvider.kt
@@ -3,33 +3,17 @@ package com.jeanbarrossilva.aurelius.ui.theme.colors
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import com.jeanbarrossilva.aurelius.R
 import com.jeanbarrossilva.aurelius.ui.theme.AureliusTheme
 
 /**
  * Provides the [Colors] to be used in the [AureliusTheme].
  *
+ * @param colors [Colors] to be provided.
  * @param content Content to be able to access the provided value through [LocalColors].
  **/
 @Composable
-internal fun ColorsProvider(content: @Composable () -> Unit) {
-    CompositionLocalProvider(
-        LocalColors provides Colors.of(
-            R.color.aurelius_background,
-            R.color.aurelius_scrim,
-            container = LayeredColors.of(
-                R.color.aurelius_container_primary,
-                R.color.aurelius_container_secondary,
-                R.color.aurelius_container_tertiary
-            ),
-            content = LayeredColors.of(
-                R.color.aurelius_content_primary,
-                R.color.aurelius_content_secondary,
-                R.color.aurelius_content_tertiary
-            ),
-            TextColors.of(R.color.aurelius_text_highlighted, R.color.aurelius_text_default)
-        )
-    ) {
+internal fun ColorsProvider(colors: Colors, content: @Composable () -> Unit) {
+    CompositionLocalProvider(LocalColors provides colors) {
         CompositionLocalProvider(
             LocalContentColor provides AureliusTheme.colors.text.default,
             content = content

--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/colors/TextColors.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/colors/TextColors.kt
@@ -4,6 +4,7 @@ import androidx.annotation.ColorRes
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
+import com.jeanbarrossilva.aurelius.R
 
 /**
  * [Color]s of hierarchically and/or contextually distinct texts.
@@ -16,6 +17,10 @@ data class TextColors internal constructor(val highlighted: Color, val default: 
         /** [TextColors] with [Color.Unspecified] values. **/
         internal val Unspecified =
             TextColors(highlighted = Color.Unspecified, default = Color.Unspecified)
+
+        /** [TextColors] that are provided by default. **/
+        val default
+            @Composable get() = of(R.color.aurelius_text_highlighted, R.color.aurelius_text_default)
 
         @Composable
         internal fun of(@ColorRes highlighted: Int, @ColorRes default: Int): TextColors {

--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/colors/layered/LayeredColors.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/colors/layered/LayeredColors.kt
@@ -1,4 +1,4 @@
-package com.jeanbarrossilva.aurelius.ui.theme.colors
+package com.jeanbarrossilva.aurelius.ui.theme.colors.layered
 
 import androidx.annotation.ColorRes
 import androidx.compose.runtime.Composable

--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/colors/layered/LayeredColorsDefaults.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/colors/layered/LayeredColorsDefaults.kt
@@ -1,0 +1,22 @@
+package com.jeanbarrossilva.aurelius.ui.theme.colors.layered
+
+import androidx.compose.runtime.Composable
+import com.jeanbarrossilva.aurelius.R
+
+object LayeredColorsDefaults {
+    /** Container [LayeredColors] that are provided by default. **/
+    val container
+        @Composable get() = LayeredColors.of(
+            R.color.aurelius_container_primary,
+            R.color.aurelius_container_secondary,
+            R.color.aurelius_container_tertiary
+        )
+
+    /** Content [LayeredColors] that are provided by default. **/
+    val content
+        @Composable get() = LayeredColors.of(
+            R.color.aurelius_content_primary,
+            R.color.aurelius_content_secondary,
+            R.color.aurelius_content_tertiary
+        )
+}


### PR DESCRIPTION
Allows for the colors of the theme to be customized by just passing in a `Colors` param into `AureliusTheme`.