### PR TITLE
Tag `Dialog` buttons

### DIFF
--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/layout/dialog/Dialog.ConfirmationButton.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/layout/dialog/Dialog.ConfirmationButton.kt
@@ -8,12 +8,16 @@ import androidx.compose.material3.ProvideTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import com.jeanbarrossilva.aurelius.ui.layout.background.Background
 import com.jeanbarrossilva.aurelius.ui.layout.background.BackgroundContentSizing
 import com.jeanbarrossilva.aurelius.ui.theme.AureliusTheme
+
+/** Tag that identifies the [ConfirmationButton] for testing purposes. **/
+const val DIALOG_CONFIRMATION_BUTTON_TAG = "dialog_confirmation_button"
 
 /**
  * Confirmation [Button] of a [Dialog].
@@ -30,7 +34,7 @@ fun ConfirmationButton(
 ) {
     Button(
         onClick,
-        modifier,
+        modifier.testTag(DIALOG_CONFIRMATION_BUTTON_TAG),
         shape = DialogDefaults.buttonShape,
         colors = ButtonDefaults.buttonColors(
             containerColor = AureliusTheme.colors.container.primary,

--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/layout/dialog/Dialog.NeutralButton.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/layout/dialog/Dialog.NeutralButton.kt
@@ -7,11 +7,15 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.jeanbarrossilva.aurelius.ui.layout.background.Background
 import com.jeanbarrossilva.aurelius.ui.layout.background.BackgroundContentSizing
 import com.jeanbarrossilva.aurelius.ui.theme.AureliusTheme
+
+/** Tag that identifies the [NeutralButton] for testing purposes. **/
+const val DIALOG_NEUTRAL_BUTTON_TAG = "dialog_neutral_button"
 
 /**
  * Neutral, non-highlighted [Button] of a [Dialog].
@@ -26,7 +30,11 @@ fun NeutralButton(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit
 ) {
-    TextButton(onClick, modifier, shape = DialogDefaults.buttonShape) {
+    TextButton(
+        onClick,
+        modifier.testTag(DIALOG_NEUTRAL_BUTTON_TAG),
+        shape = DialogDefaults.buttonShape
+    ) {
         ProvideTextStyle(AureliusTheme.text.body.copy(AureliusTheme.colors.text.highlighted)) {
             content()
         }

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -21,8 +21,8 @@ object Versions {
     val java = JavaVersion.VERSION_11
 
     object Aurelius {
-        const val CODE = 8
-        const val NAME = "1.3.1"
+        const val CODE = 9
+        const val NAME = "1.4.0"
         const val SDK_COMPILE = 33
         const val SDK_MIN = 21
         const val SDK_TARGET = SDK_COMPILE


### PR DESCRIPTION
Tags [`Dialog`](https://github.com/jeanbarrossilva/aurelius-android/blob/c95dd5945c5443e9de920e0105aa4d3c2842a843/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/layout/dialog/Dialog.kt)'s neutral and confirmation buttons.