### PR TITLE
Internalize `Sizes`' contructor

### DIFF
--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/sizes/Sizes.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/sizes/Sizes.kt
@@ -7,7 +7,7 @@ package com.jeanbarrossilva.aurelius.ui.theme.sizes
  * padding.
  * @param margin Reserved spaces for hierarchically greater components.
  **/
-data class Sizes(val spacing: Spacing, val margin: Margin) {
+data class Sizes internal constructor(val spacing: Spacing, val margin: Margin) {
     companion object {
         /** [Sizes] with unspecified values. **/
         internal val Unspecified = Sizes(Spacing.Unspecified, Margin.Unspecified)


### PR DESCRIPTION
Makes the constructor of `Sizes` internal so that consumers cannot instantiate it.

Closes #26.