### PR TITLE
Require theme for `Dialog` and `TopAppBar`'s `ActionButton`

### DIFF
--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/layout/dialog/Dialog.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/layout/dialog/Dialog.kt
@@ -42,6 +42,8 @@ fun Dialog(
     modifier: Modifier = Modifier,
     buttons: @Composable (RowScope.() -> Unit)? = null
 ) {
+    AureliusTheme.requireFor("Dialog")
+
     Dialog(onDismissalRequest) {
         Column(
             modifier

--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/layout/scaffold/topappbar/TopAppBar.ActionButton.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/layout/scaffold/topappbar/TopAppBar.ActionButton.kt
@@ -33,6 +33,8 @@ fun ActionButton(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit
 ) {
+    AureliusTheme.requireFor("ActionButton")
+
     IconButton(
         onClick,
         modifier


### PR DESCRIPTION
Requires that [`AureliusTheme`](https://github.com/jeanbarrossilva/aurelius-android/blob/6f82e37f06af8ceb758cee25ba8a804159f98ca4/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/AureliusTheme.kt) be provided for a [`Dialog`](https://github.com/jeanbarrossilva/aurelius-android/blob/6f82e37f06af8ceb758cee25ba8a804159f98ca4/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/layout/dialog/Dialog.kt) and an [`ActionButton`](https://github.com/jeanbarrossilva/aurelius-android/blob/6f82e37f06af8ceb758cee25ba8a804159f98ca4/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/layout/scaffold/topappbar/TopAppBar.ActionButton.kt), since they both throw an exception because of unspecified sizes.