### PR TITLE
Add size values in XML

### DIFF
--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/sizes/Sizes.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/sizes/Sizes.kt
@@ -16,6 +16,6 @@ data class Sizes internal constructor(val spacing: Spacing, val margin: Margin) 
 
         /** [Sizes] that are provided by default. **/
         val default
-            @Composable get() = Sizes(Spacing.Default, Margin.default)
+            @Composable get() = Sizes(Spacing.default, Margin.default)
     }
 }

--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/sizes/Spacing.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/sizes/Spacing.kt
@@ -1,7 +1,9 @@
 package com.jeanbarrossilva.aurelius.ui.theme.sizes
 
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
+import com.jeanbarrossilva.aurelius.R
 
 /**
  * Sizes for spacing, such as the distance between one component and another or padding.
@@ -30,7 +32,13 @@ data class Spacing internal constructor(
         )
 
         /** [Spacing] that's provided by default. **/
-        val Default =
-            Spacing(huge = 32.dp, large = 24.dp, medium = 16.dp, small = 8.dp, tiny = 4.dp)
+        val default
+            @Composable get() = Spacing(
+                huge = dimensionResource(R.dimen.aurelius_sizes_spacing_huge),
+                large = dimensionResource(R.dimen.aurelius_sizes_spacing_large),
+                medium = dimensionResource(R.dimen.aurelius_sizes_spacing_medium),
+                small = dimensionResource(R.dimen.aurelius_sizes_spacing_small),
+                tiny = dimensionResource(R.dimen.aurelius_sizes_spacing_tiny)
+            )
     }
 }

--- a/aurelius/src/main/res/values/sizes.xml
+++ b/aurelius/src/main/res/values/sizes.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="aurelius_sizes_spacing_huge">32dp</dimen>
+    <dimen name="aurelius_sizes_spacing_large">24dp</dimen>
+    <dimen name="aurelius_sizes_spacing_medium">16dp</dimen>
+    <dimen name="aurelius_sizes_spacing_small">8dp</dimen>
+    <dimen name="aurelius_sizes_spacing_tiny">4dp</dimen>
+</resources>

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -21,8 +21,8 @@ object Versions {
     val java = JavaVersion.VERSION_11
 
     object Aurelius {
-        const val CODE = 10
-        const val NAME = "1.5.0"
+        const val CODE = 11
+        const val NAME = "1.6.0"
         const val SDK_COMPILE = 33
         const val SDK_MIN = 21
         const val SDK_TARGET = SDK_COMPILE


### PR DESCRIPTION
Makes [`sizes.xml`](https://github.com/jeanbarrossilva/aurelius-android/blob/9d7fa7f5647e5c54d998d16297e4cbbe04e8fe9b/aurelius/src/main/res/values/sizes.xml) the source of [`Sizes`](https://github.com/jeanbarrossilva/aurelius-android/blob/9d7fa7f5647e5c54d998d16297e4cbbe04e8fe9b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/sizes/Sizes.kt)' provided default [`Spacing`](https://github.com/jeanbarrossilva/aurelius-android/blob/9d7fa7f5647e5c54d998d16297e4cbbe04e8fe9b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/sizes/Spacing.kt) values.