### PR TITLE
Fix failing Compose previews because of fraction resource

### DIFF
--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/shapes/Shapes.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/shapes/Shapes.kt
@@ -3,6 +3,7 @@ package com.jeanbarrossilva.aurelius.ui.theme.shapes
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Shapes as MaterialShapes
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.dp
 import com.jeanbarrossilva.aurelius.R
@@ -29,6 +30,19 @@ data class Shapes internal constructor(
         get() = MaterialShapes(extraSmall = tiny, small, medium, large, extraLarge = huge)
 
     companion object {
+        /**
+         * Percent used to create the default [tiny][tiny] [RoundedCornerShape].
+         *
+         * A constant value is used while in edit mode because Compose previews fail to load values
+         * from [fractionResource].
+         **/
+        private val tinyPercent
+            @Composable get() = if (LocalView.current.isInEditMode) {
+                50
+            } else {
+                fractionResource(R.fraction.aurelius_shapes_tiny_size).times(100).toInt()
+            }
+
         /** [Shapes] with zeroed [RoundedCornerShape]s. **/
         internal val Unspecified = Shapes(
             huge = RoundedCornerShape(0.dp),
@@ -45,9 +59,7 @@ data class Shapes internal constructor(
                 large = RoundedCornerShape(dimensionResource(R.dimen.aurelius_shapes_large_size)),
                 medium = RoundedCornerShape(dimensionResource(R.dimen.aurelius_shapes_medium_size)),
                 small = RoundedCornerShape(dimensionResource(R.dimen.aurelius_shapes_small_size)),
-                tiny = RoundedCornerShape(
-                    fractionResource(R.fraction.aurelius_shapes_tiny_size).times(100).toInt()
-                )
+                tiny = RoundedCornerShape(tinyPercent)
             )
     }
 }


### PR DESCRIPTION
Compose previews are failing due to a fraction resource ([`R.fraction.aurelius_shapes_tiny_size`](https://github.com/jeanbarrossilva/aurelius-android/blob/8c4334be3749798bc46e9f1df2a80961f02922c3/aurelius/src/main/res/values/shapes.xml#L7)) being used to create the tiny shape that's provided by default by the theme. More specifically, a [`Resources.NotFoundException`](https://developer.android.com/reference/android/content/res/Resources.NotFoundException) is thrown, and the cause is yet unknown.

The (non-ideal) solution is to use a constant value instead of reading from the resource while previewing.