### PR TITLE
Add `Visibility` in XML

### DIFF
--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/AureliusTheme.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/AureliusTheme.kt
@@ -95,7 +95,7 @@ fun AureliusTheme(
     shapes: Shapes = Shapes.default,
     sizes: Sizes = Sizes.default,
     text: Text = Text.default,
-    visibility: Visibility = Visibility.Default,
+    visibility: Visibility = Visibility.default,
     content: @Composable () -> Unit
 ) {
     CompositionLocalProvider(

--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/shapes/Shapes.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/shapes/Shapes.kt
@@ -1,13 +1,12 @@
 package com.jeanbarrossilva.aurelius.ui.theme.shapes
 
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Shapes as MaterialShapes
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.dp
 import com.jeanbarrossilva.aurelius.R
 import com.jeanbarrossilva.aurelius.utils.fractionResource
+import androidx.compose.material3.Shapes as MaterialShapes
 
 /**
  * [RoundedCornerShape]s for shaping UI components based on their size.
@@ -30,18 +29,8 @@ data class Shapes internal constructor(
         get() = MaterialShapes(extraSmall = tiny, small, medium, large, extraLarge = huge)
 
     companion object {
-        /**
-         * Percent used to create the default [tiny][tiny] [RoundedCornerShape].
-         *
-         * A constant value is used while in edit mode because Compose previews fail to load values
-         * from [fractionResource].
-         **/
-        private val tinyPercent
-            @Composable get() = if (LocalView.current.isInEditMode) {
-                50
-            } else {
-                fractionResource(R.fraction.aurelius_shapes_tiny_size).times(100).toInt()
-            }
+        /** Default [tiny][tiny] [RoundedCornerShape] percent to fallback to. **/
+        private const val DEFAULT_TINY_PERCENT_FALLBACK = 50
 
         /** [Shapes] with zeroed [RoundedCornerShape]s. **/
         internal val Unspecified = Shapes(
@@ -59,7 +48,12 @@ data class Shapes internal constructor(
                 large = RoundedCornerShape(dimensionResource(R.dimen.aurelius_shapes_large_size)),
                 medium = RoundedCornerShape(dimensionResource(R.dimen.aurelius_shapes_medium_size)),
                 small = RoundedCornerShape(dimensionResource(R.dimen.aurelius_shapes_small_size)),
-                tiny = RoundedCornerShape(tinyPercent)
+                tiny = RoundedCornerShape(
+                    fractionResource(R.fraction.aurelius_shapes_tiny_size)
+                        ?.times(100)
+                        ?.toInt()
+                        ?: DEFAULT_TINY_PERCENT_FALLBACK
+                )
             )
     }
 }

--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/shapes/Shapes.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/shapes/Shapes.kt
@@ -1,12 +1,12 @@
 package com.jeanbarrossilva.aurelius.ui.theme.shapes
 
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Shapes as MaterialShapes
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.unit.dp
 import com.jeanbarrossilva.aurelius.R
 import com.jeanbarrossilva.aurelius.utils.fractionResource
-import androidx.compose.material3.Shapes as MaterialShapes
 
 /**
  * [RoundedCornerShape]s for shaping UI components based on their size.

--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/visibility/Visibility.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/visibility/Visibility.kt
@@ -16,14 +16,21 @@ data class Visibility internal constructor(
     @FloatRange(from = 0.0, to = 1.0) val low: Float
 ) {
     companion object {
+        /** Default [medium] value to fallback to. **/
+        private const val DEFAULT_MEDIUM_FALLBACK = .5f
+
+        /** Default [low] value to fallback to. **/
+        private const val DEFAULT_LOW_FALLBACK = .38f
+
         /** [Visibility] with zeroed values. **/
         internal val Unspecified = Visibility(medium = 0f, low = 0f)
 
         /** [Visibility] that's provided by default. **/
         val default
             @Composable get() = Visibility(
-                medium = fractionResource(R.fraction.aurelius_visibility_low),
-                low = fractionResource(R.fraction.aurelius_visibility_low)
+                medium = fractionResource(R.fraction.aurelius_visibility_low)
+                    ?: DEFAULT_MEDIUM_FALLBACK,
+                low = fractionResource(R.fraction.aurelius_visibility_low) ?: DEFAULT_LOW_FALLBACK
             )
     }
 }

--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/visibility/Visibility.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/visibility/Visibility.kt
@@ -1,6 +1,9 @@
 package com.jeanbarrossilva.aurelius.ui.theme.visibility
 
 import androidx.annotation.FloatRange
+import androidx.compose.runtime.Composable
+import com.jeanbarrossilva.aurelius.R
+import com.jeanbarrossilva.aurelius.utils.fractionResource
 
 /**
  * Represents content opacity.
@@ -17,6 +20,10 @@ data class Visibility internal constructor(
         internal val Unspecified = Visibility(medium = 0f, low = 0f)
 
         /** [Visibility] that's provided by default. **/
-        val Default = Visibility(medium = .5f, low = .38f)
+        val default
+            @Composable get() = Visibility(
+                medium = fractionResource(R.fraction.aurelius_visibility_low),
+                low = fractionResource(R.fraction.aurelius_visibility_low)
+            )
     }
 }

--- a/aurelius/src/main/java/com/jeanbarrossilva/aurelius/utils/Resource.extensions.kt
+++ b/aurelius/src/main/java/com/jeanbarrossilva/aurelius/utils/Resource.extensions.kt
@@ -1,5 +1,6 @@
 package com.jeanbarrossilva.aurelius.utils
 
+import android.content.res.Resources
 import androidx.annotation.FloatRange
 import androidx.annotation.FractionRes
 import androidx.compose.runtime.Composable
@@ -12,6 +13,11 @@ import androidx.compose.ui.platform.LocalContext
  **/
 @Composable
 @FloatRange(from = 0.0, to = 1.0)
-fun fractionResource(@FractionRes id: Int): Float {
-    return LocalContext.current.resources.getFraction(id, 1, 1)
+fun fractionResource(@FractionRes id: Int): Float? {
+    val context = LocalContext.current
+    return try {
+        context.resources.getFraction(id, 1, 1)
+    } catch (_: Resources.NotFoundException) {
+        null
+    }
 }

--- a/aurelius/src/main/res/values/visibility.xml
+++ b/aurelius/src/main/res/values/visibility.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <fraction name="aurelius_visibility_medium">50%</fraction>
+    <fraction name="aurelius_visibility_low">38%</fraction>
+</resources>


### PR DESCRIPTION
Makes [`visibility.xml`](https://github.com/jeanbarrossilva/aurelius-android/blob/311291328ba4f4acf3fa7b8d222e651fe2816b6f/aurelius/src/main/res/values/visibility.xml) the source of truth for the [`Visibility`](https://github.com/jeanbarrossilva/aurelius-android/blob/311291328ba4f4acf3fa7b8d222e651fe2816b6f/aurelius/src/main/java/com/jeanbarrossilva/aurelius/ui/theme/visibility/Visibility.kt) values that are provided by default by the theme.